### PR TITLE
[zep noup] zephyr: module: Add module file for psa-arch-tests

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,1 @@
+name: psa-arch-tests


### PR DESCRIPTION
Add module file for psa-arch-tests repository.
This allows us to point this repository with a
ZEPHYR_<module>_MODULE_DIR variable when included by zephyr.


(cherry picked from commit 588572c0ebd835c7e0929eaf3007d4fbadb47b5b)